### PR TITLE
Fix for issues #10 and #12

### DIFF
--- a/gulp-cssimport.js
+++ b/gulp-cssimport.js
@@ -14,9 +14,9 @@ var Chunk = require("./chunk");
 var defaults = {
 	extensions: null,
 	filter: null,
-	matchPattern: null,
+	matchPattern: "*",
 	matchOptions: {
-		matchBase: true
+		matchBase: false
 	},
 	limit: 5000
 };
@@ -36,10 +36,10 @@ module.exports = function cssImport(options) {
 			return x.trim();
 		});
 	}
-	
+
 	var stream;
 	var cssCount = 0;
-	
+
 	function fileContents(data, encoding, callback) {
 		if (!stream) {
 			stream = this;


### PR DESCRIPTION
I have had the same problem as was reported in issue #12.  I found that the cause was the options that were being sent to  minimatch.  A simple patch to the default options has cured the problem cited in issue  #12 and should also help with issue #10.  This patch I have submitted incorporate the alteration of those two default option settings.  These are the condition I have determined for proper operation:  the matchPattern can not be either null nor an empty string;  matchBase must be set to false.  If either of these condition are not met, the base filename of any css file that is actually processed will have multiple "../" prepended to it, to effectivly take the file down to one directory only,  Example if the file name is style.css and the directory path (rooted at the directory where gulpfile.js is located) is app/1/2/style/css  the filename will be converted to  ../../../../style.css and when it is concatenated to the the directory name, the file wil be written to app/1/2/style/css../../../../style.css   in effect placing the file into the app directory.